### PR TITLE
Wien: update line styles

### DIFF
--- a/Sources/TripKit/Provider/Implementations/WienProvider.swift
+++ b/Sources/TripKit/Provider/Implementations/WienProvider.swift
@@ -13,21 +13,15 @@ public class WienProvider: AbstractEfaWebProvider {
         
         styles = [
             // Wien
-            "SS1": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#1e5cb3"), foregroundColor: LineStyle.white),
-            "SS2": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#59c594"), foregroundColor: LineStyle.white),
-            "SS3": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#c8154c"), foregroundColor: LineStyle.white),
-            "SS7": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#dc35a3"), foregroundColor: LineStyle.white),
-            "SS40": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#f24d3e"), foregroundColor: LineStyle.white),
-            "SS45": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#0f8572"), foregroundColor: LineStyle.white),
-            "SS50": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#34b6e5"), foregroundColor: LineStyle.white),
-            "SS60": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#82b429"), foregroundColor: LineStyle.white),
-            "SS80": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#e96619"), foregroundColor: LineStyle.white),
-            
-            "UU1": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#c6292a"), foregroundColor: LineStyle.white),
-            "UU2": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#a82783"), foregroundColor: LineStyle.white),
-            "UU3": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#f39315"), foregroundColor: LineStyle.white),
-            "UU4": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#23a740"), foregroundColor: LineStyle.white),
-            "UU6": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#be762c"), foregroundColor: LineStyle.white)
+            "S": LineStyle(shape: .circle, backgroundColor: LineStyle.parseColor("#009fe3"), foregroundColor: LineStyle.white),
+            "B": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#0a2a5d"), foregroundColor: LineStyle.white),
+            "BN": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#0a2a5d"), foregroundColor: LineStyle.yellow),
+
+            "UU1": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#d8222a"), foregroundColor: LineStyle.white),
+            "UU2": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#935e98"), foregroundColor: LineStyle.white),
+            "UU3": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#e67a2b"), foregroundColor: LineStyle.white),
+            "UU4": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#009460"), foregroundColor: LineStyle.white),
+            "UU6": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#8c633c"), foregroundColor: LineStyle.white),
         ]
     }
     


### PR DESCRIPTION
Wien has only one style for all "S-Bahn" trains, except for areas where multiple have the same route, there they are colored in green/white and pink/white.

The same goes for all busses and trams. One question: as these are not customized by line, should they just use the default color for that transportation mode or is it fine the way I implemented it here to use the operator's colorscheme?

sources:

https://www.wienmobil.at/en/lines?showFirstLast=true&planDate=2025-06-08T22:00:00Z

https://www.wienerlinien.at/documents/2424499/7499660/Gesamtnetzplan_Tag.pdf/7d41243a-ef96-60d8-4b6d-fd1699f036ac?t=1759316459661

https://www.wienerlinien.at/documents/2424499/7499660/Gesamtnetzplan_Nacht.pdf/b9f673c5-320b-46c0-5e5e-63eca46f67fd?t=1759316463768