### PR TITLE
ÖBB: add custom style for City Airport Train

### DIFF
--- a/Sources/TripKit/Provider/Implementations/OebbProvider.swift
+++ b/Sources/TripKit/Provider/Implementations/OebbProvider.swift
@@ -30,6 +30,7 @@ public class OebbProvider: AbstractHafasClientInterfaceProvider {
         apiClient = ["id": "OEBB", "type": "IPH", "name": "oebbADHOC", "v": "6020300"]
         styles = [
             "WESTbahn Management GmbH|I": LineStyle(shape: .rect, backgroundColor: LineStyle.white, foregroundColor: LineStyle.parseColor("#0077b5"), borderColor: LineStyle.parseColor("#0077b5")),
+            "CAT - CityAirportTrain|R": LineStyle(shape: .rect, backgroundColor: LineStyle.parseColor("#7bbc36"), foregroundColor: LineStyle.white, borderColor: 0),
         ]
     }
     


### PR DESCRIPTION
CAT - CityAirportTrain is a train service between "Wien Mitte" and "Wien Flughafen" and usually highlighted in green:

https://www.cityairporttrain.com/de/
https://de.wikipedia.org/wiki/City_Airport_Train