### PR TITLE
HCI: hide ÖBB AIRail information

### DIFF
--- a/Sources/TripKit/Provider/AbstractHafasClientInterfaceProvider.swift
+++ b/Sources/TripKit/Provider/AbstractHafasClientInterfaceProvider.swift
@@ -1146,6 +1146,8 @@ public class AbstractHafasClientInterfaceProvider: AbstractHafasProvider {
                         break
                     case "weather":
                         break
+                    case "zn": // ÖBB: AIRail flugnummer und strecke
+                        break
                     default:
                         guard let txt = rem.txtN?.stripHTMLTags() else { continue }
                         switch rem.type ?? "" {


### PR DESCRIPTION
This change hides the last row in the following screenshot, this seems to be the Austrian Airlines flight number and route of the train, Salzburg->Linz->Wien. In my opinion this information does not need to be included.

<img width="1170" height="643" alt="image" src="https://github.com/user-attachments/assets/74e12ba2-47fc-49a7-9cbe-05f45ae6287d" />



One question: I am not sure of the remL.codes are unique across all HAFAS endpoints. I have not seen any conflicts of codes yet but that will only be a question of time. In my opinion it would make sense to make the message parsing overrideable by provider and add new/specific messages only per provider. Any thoughts on this?