### PR TITLE
ÖBB: fix name in comment

### DIFF
--- a/Sources/TripKit/Provider/Implementations/OebbProvider.swift
+++ b/Sources/TripKit/Provider/Implementations/OebbProvider.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// ÖBB Personalverkehr AG (AT)
+/// ÖBB Personenverkehr AG (AT)
 public class OebbProvider: AbstractHafasClientInterfaceProvider {
     
     static let API_BASE = "https://fahrplan.oebb.at/bin/"


### PR DESCRIPTION
The correct name for ÖBB is "ÖBB Personenverkehr AG" instead of "Personalverkehr:

https://personenverkehr.oebb.at/
https://de.wikipedia.org/wiki/%C3%96BB-Personenverkehr

I am aware that this change will not fix the naming in the app, but I would like to use this PR as a request to also have it changed there:

![screenshot_1](https://github.com/user-attachments/assets/c1c2d459-e30f-4e26-967a-d99ef44b277f)
![screenshot_2](https://github.com/user-attachments/assets/40a8e027-0136-4ab3-874b-20404b4c13c7)
