### PR TITLE
fix: apply night-bus style before generic product style

### DIFF
--- a/Sources/TripKit/Provider/AbstractNetworkProvider.swift
+++ b/Sources/TripKit/Provider/AbstractNetworkProvider.swift
@@ -152,25 +152,20 @@ public class AbstractNetworkProvider: NetworkProvider {
                     return style
                 }
                 
-                style = styles["\(network)|\(product.rawValue)"]
-                if let style = style {
-                    return style
-                }
-                
                 if product == .bus, let label = label, label.hasPrefix("N") {
                     style = styles["\(network)|BN"]
                     if let style = style {
                         return style
                     }
                 }
+                
+                style = styles["\(network)|\(product.rawValue)"]
+                if let style = style {
+                    return style
+                }
             }
             
             style = styles[product.rawValue + (label ?? "")]
-            if let style = style {
-                return style
-            }
-            
-            style = styles[product.rawValue]
             if let style = style {
                 return style
             }
@@ -180,6 +175,11 @@ public class AbstractNetworkProvider: NetworkProvider {
                 if let style = style {
                     return style
                 }
+            }
+            
+            style = styles[product.rawValue]
+            if let style = style {
+                return style
             }
         }
         


### PR DESCRIPTION
Currently the night-bus styles of e.g. the WienProvider are not displayed correctly. The night busses are shown dark blue with a white text instead of yellow:

```
"B": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#0a2a5d"), foregroundColor: LineStyle.white),
"BN": LineStyle(shape: .rounded, backgroundColor: LineStyle.parseColor("#0a2a5d"), foregroundColor: LineStyle.yellow),
```

With this change the night styles will be applied before the generic product styles.