### PR TITLE
ÖBB: switch product index 4 to highspeedTrain

### DIFF
--- a/Sources/TripKit/Provider/Implementations/OebbProvider.swift
+++ b/Sources/TripKit/Provider/Implementations/OebbProvider.swift
@@ -4,7 +4,7 @@ import Foundation
 public class OebbProvider: AbstractHafasClientInterfaceProvider {
     
     static let API_BASE = "https://fahrplan.oebb.at/bin/"
-    static let PRODUCTS_MAP: [Product?] = [.highSpeedTrain, .highSpeedTrain, .highSpeedTrain, .regionalTrain, .regionalTrain, .suburbanTrain, .bus, .ferry, .subway, .tram, .highSpeedTrain, .onDemand, .highSpeedTrain]
+    static let PRODUCTS_MAP: [Product?] = [.highSpeedTrain, .highSpeedTrain, .highSpeedTrain, .highSpeedTrain, .regionalTrain, .suburbanTrain, .bus, .ferry, .subway, .tram, .highSpeedTrain, .onDemand, .highSpeedTrain]
     
     public override var supportedLanguages: Set<String> { ["de"] }
     


### PR DESCRIPTION
from the JS implementation: https://github.com/public-transport/hafas-client/blob/885ea5ec1b89782850fcf90ce4f13a3a3d908554/p/oebb/products.js#L21 it seems that bit 4 should not be a .regionalTrain but rather a .highSpeedTrain

The ÖBB API returns a "cls" value of 8 for Nightjet trains, which should in my opinion be shown as highspeed trains instead of regional trains. The SearchChProvider also maps "NJ" trains to .highSpeedTrain already.

```
{
    "himIdL": [...],
    "prodCtx": {
	"catCode": "3",
	"catIn": "NJ",
	"catOutL": "nightjet",
	"name": "NJ 40490",
	// ...
    },
    "cls": 8,
    "icoX": 2,
    "name": "NJ 40490",
    "nameS": "NJ 40490",
    "number": "40490",
    "oprX": 0,
},
```

From what i was able to find, cls: 8 is only returned for "EuroNight" and "NightJet" trains.